### PR TITLE
relax primitive package version restriction

### DIFF
--- a/examples/MonteCarlo.hs
+++ b/examples/MonteCarlo.hs
@@ -5,6 +5,7 @@ import System.Random.SFMT
 montePi :: Int -> GenIO -> IO Double
 montePi len gen = loop (0::Int) (0::Int)
   where
+    loop :: Int -> Int -> IO Double
     loop !i !cnt
         | i >= len  = return $ 4 * (fromIntegral cnt / fromIntegral len)
         | otherwise = do

--- a/sfmt.cabal
+++ b/sfmt.cabal
@@ -1,5 +1,5 @@
 name:                sfmt
-version:             0.1.0
+version:             0.1.1
 synopsis:            SIMD-oriented Fast Mersenne Twister(SFMT) binding.
 description:         this library has mwc-random<http://hackage.haskell.org/package/mwc-random> like api.
 license:             BSD3
@@ -21,7 +21,7 @@ library
   exposed-modules:     System.Random.SFMT
   other-modules:       System.Random.SFMT.Foreign
   build-depends:       base       >=4.6  && <4.9
-                     , primitive  >=0.5  && <0.6
+                     , primitive  >=0.5  && <0.7
                      , bytestring >=0.10 && <0.11
                      , entropy    >=0.3  && <0.4
   default-language:    Haskell2010


### PR DESCRIPTION
表題の通り、primitiveのバージョンについて、0.6.0.0でもコンパイル、実行できるように修正してみました。

primitiveは0.6以降、これまでPrimMonadに対して定義していた操作の一部を、PrimBaseというサブクラスに対して定義するようにAPIの設計を変更したようです。これに対する修正を入れましたが、もしかしたら、こちらの理解不足で問題が起きているかもしれません。

もし問題が無いようでしたら、ご確認の上、そちらのリポジトリにマージしていただけないでしょうか。
